### PR TITLE
Add trimal to dependency list on Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,7 @@ RUN wget --quiet "${RC_SRC_URL}" && \
     unzip ${RC_COMMIT}.zip && \
     rm ${RC_COMMIT}.zip && \
     mv -v ribosomal_snakemake-${RC_COMMIT} /ribosomal_snakemake && \
-    mamba create --name ribosomal_snakemake -c conda-forge -c bioconda \
+    mamba create -y --name ribosomal_snakemake -c conda-forge -c bioconda \
         'snakemake>=3.5' \
         'python==3.11' \
         'biopython>=1.77' \
@@ -53,7 +53,8 @@ RUN wget --quiet "${RC_SRC_URL}" && \
         'mafft>=7.429' \
         'fasttree>=2.1.10' \
         'iqtree>=1.6.11' \
-        'ncbi-genome-download>=0.3.0' && \
+        'ncbi-genome-download>=0.3.0' \
+        'trimal>=1.5.0' && \
     mamba clean -a -y
 
 # set locale settings to UTF-8

--- a/tasks/task_rctyping.wdl
+++ b/tasks/task_rctyping.wdl
@@ -5,7 +5,7 @@ task ribosomal_snakemake {
     Array[File] genbank
     File rc_proteins
     String species
-    String docker="us-central1-docker.pkg.dev/general-theiagen/jidc-trust/ribosomal-wdl:1.0.0"
+    String docker="us-docker.pkg.dev/general-theiagen/internal/ribosomal-wdl:299bb2"
     Int memory = 32
     Int cpu = 4
     Int disk_size = 50
@@ -58,7 +58,7 @@ task ribosomal_snakemake {
     File rctype_fasta = "rctype_.updateriboprot.fasta"
     File rctype_deduped_fasta = "rctype_.updateriboprot.fastadedupe.fasta"
     File rctype_aln = "rctype_.updateriboprotdedupe.aln"
-    File rctype_treefile = "rctype_.updateriboprotdedupe.aln.treefile"
+    File? rctype_treefile = "rctype_.updateriboprotdedupe.aln.treefile"
     File rctype_proteins_fasta = "rctype_concatenated_ribosomal_proteins_db.fasta"
     File rctype_proteins_fasta2 = "rctype_concatenated_ribosomal_proteins_db.fasta_2"
     File rctype_extracted_fasta = "rctype_extracted.fasta"

--- a/tasks/task_rctyping.wdl
+++ b/tasks/task_rctyping.wdl
@@ -5,7 +5,7 @@ task ribosomal_snakemake {
     Array[File] genbank
     File rc_proteins
     String species
-    String docker="us-docker.pkg.dev/general-theiagen/internal/ribosomal-wdl:299bb2"
+    String docker = "us-docker.pkg.dev/general-theiagen/internal/ribosomal-wdl:299bb2"
     Int memory = 32
     Int cpu = 4
     Int disk_size = 50

--- a/tasks/task_rctyping.wdl
+++ b/tasks/task_rctyping.wdl
@@ -58,7 +58,7 @@ task ribosomal_snakemake {
     File rctype_fasta = "rctype_.updateriboprot.fasta"
     File rctype_deduped_fasta = "rctype_.updateriboprot.fastadedupe.fasta"
     File rctype_aln = "rctype_.updateriboprotdedupe.aln"
-    File? rctype_treefile = "rctype_.updateriboprotdedupe.aln.treefile"
+    File rctype_treefile = "rctype_.updateriboprotdedupe_trimmed.aln.log"
     File rctype_proteins_fasta = "rctype_concatenated_ribosomal_proteins_db.fasta"
     File rctype_proteins_fasta2 = "rctype_concatenated_ribosomal_proteins_db.fasta_2"
     File rctype_extracted_fasta = "rctype_extracted.fasta"

--- a/workflows/wf_rctyping.wdl
+++ b/workflows/wf_rctyping.wdl
@@ -23,7 +23,6 @@ workflow rctyping {
     File rctype_fasta = rc_snakemake.rctype_fasta
     File rctype_deduped_fasta = rc_snakemake.rctype_deduped_fasta
     File rctype_aln = rc_snakemake.rctype_aln
-    File? rctype_treefile = rc_snakemake.rctype_treefile
     File rctype_proteins_fasta = rc_snakemake.rctype_proteins_fasta
     File rctype_proteins_fasta2 = rc_snakemake.rctype_proteins_fasta2
     File rctype_extracted_fasta = rc_snakemake.rctype_extracted_fasta

--- a/workflows/wf_rctyping.wdl
+++ b/workflows/wf_rctyping.wdl
@@ -23,7 +23,7 @@ workflow rctyping {
     File rctype_fasta = rc_snakemake.rctype_fasta
     File rctype_deduped_fasta = rc_snakemake.rctype_deduped_fasta
     File rctype_aln = rc_snakemake.rctype_aln
-    File rctype_treefile = rc_snakemake.rctype_treefile
+    File? rctype_treefile = rc_snakemake.rctype_treefile
     File rctype_proteins_fasta = rc_snakemake.rctype_proteins_fasta
     File rctype_proteins_fasta2 = rc_snakemake.rctype_proteins_fasta2
     File rctype_extracted_fasta = rc_snakemake.rctype_extracted_fasta

--- a/workflows/wf_rctyping.wdl
+++ b/workflows/wf_rctyping.wdl
@@ -23,6 +23,7 @@ workflow rctyping {
     File rctype_fasta = rc_snakemake.rctype_fasta
     File rctype_deduped_fasta = rc_snakemake.rctype_deduped_fasta
     File rctype_aln = rc_snakemake.rctype_aln
+    File rctype_treefile = rc_snakemake.rctype_treefile
     File rctype_proteins_fasta = rc_snakemake.rctype_proteins_fasta
     File rctype_proteins_fasta2 = rc_snakemake.rctype_proteins_fasta2
     File rctype_extracted_fasta = rc_snakemake.rctype_extracted_fasta


### PR DESCRIPTION
**Main changes:**
- `trimal` was added to the environment for the workflow execution (version 1.5.0), as requested by https://github.com/jidc-trust/ribosomal_snakemake/pull/1

**Other considerations:**
- The updated container is located on `"us-docker.pkg.dev/general-theiagen/internal/ribosomal-wdl:299bb2"`, and might need to be copied to a more appropriate location
- The `rctype_treefile` output was downgraded to optional as it was not being produced in my tests (but the `ribosomal_snakemake` workflow was completed successfully). I'm unsure if this is an intended change. 